### PR TITLE
Remove 'feature(macro_rules)' attribute.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(macro_rules)]
 
 #[macro_export]
 macro_rules! version(


### PR DESCRIPTION
Now it compiles on stable rust.
